### PR TITLE
PF-349 - Added Configuration.LocaleName support

### DIFF
--- a/src/TabularCsv/Configuration.cs
+++ b/src/TabularCsv/Configuration.cs
@@ -9,6 +9,7 @@ namespace TabularCsv
         public string Id { get; set; }
         public int Priority { get; set; } = 1;
         public string Separator { get; set; }
+        public string LocaleName { get; set; }
         public int PrefaceRowCount { get; set; }
         public string PrefaceEndsWith { get; set; }
         public string PrefaceEndsBefore { get; set; }

--- a/src/TabularCsv/LocaleScope.cs
+++ b/src/TabularCsv/LocaleScope.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Globalization;
+using System.Threading;
+
+namespace TabularCsv
+{
+    public class LocaleScope : IDisposable
+    {
+        public static LocaleScope WithLocale(string localeName)
+        {
+            var cultureInfo = string.IsNullOrEmpty(localeName)
+                ? CultureInfo.InvariantCulture
+                : CultureInfo.GetCultureInfo(localeName);
+
+            return new LocaleScope(cultureInfo);
+        }
+
+        private CultureInfo PreviousThreadCulture { get; set; }
+
+        private LocaleScope(CultureInfo cultureInfo)
+        {
+            PreviousThreadCulture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = cultureInfo;
+        }
+
+        public void Dispose()
+        {
+            RestorePreviousCulture();
+        }
+
+        private void RestorePreviousCulture()
+        {
+            if (PreviousThreadCulture == null)
+                return;
+
+            Thread.CurrentThread.CurrentCulture = PreviousThreadCulture;
+            PreviousThreadCulture = null;
+        }
+    }
+}

--- a/src/TabularCsv/Parser.cs
+++ b/src/TabularCsv/Parser.cs
@@ -41,11 +41,14 @@ namespace TabularCsv
                 {
                     foreach (var configuration in configurations)
                     {
-                        var result = ParseDataFile(configuration, csvText);
+                        using (LocaleScope.WithLocale(configuration.LocaleName))
+                        {
+                            var result = ParseDataFile(configuration, csvText);
 
-                        if (result.Status == ParseFileStatus.CannotParse) continue;
+                            if (result.Status == ParseFileStatus.CannotParse) continue;
 
-                        return result;
+                            return result;
+                        }
                     }
 
                     return ParseFileResult.CannotParse();

--- a/src/TabularCsv/TabularCsv.csproj
+++ b/src/TabularCsv/TabularCsv.csproj
@@ -61,6 +61,7 @@
     <Compile Include="ConfigurationLoader.cs" />
     <Compile Include="ConfigurationValidator.cs" />
     <Compile Include="RowParser.cs" />
+    <Compile Include="LocaleScope.cs" />
     <Compile Include="TimestampType.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
All parsing takes place under the named locale, or the InvariantCulture if none is specified.

This will allow supporting parsing Spanish numbers like "3,14" when LocaleName = 'es'