### PR TITLE
PF-349 - More plugin fixes

### DIFF
--- a/src/TabularCsv/Configuration.cs
+++ b/src/TabularCsv/Configuration.cs
@@ -17,6 +17,7 @@ namespace TabularCsv
         public Regex PrefaceMustMatchRegex { get; set; }
         public int MaximumPrefaceLines { get; set; } = 50;
         public int HeaderRowCount { get; set; }
+        public bool NoDataRowsExpected { get; set; }
         public string CommentLinePrefix { get; set; }
         public bool StrictMode { get; set; } = true;
 
@@ -51,6 +52,8 @@ namespace TabularCsv
         public List<LevelSurveyDefinition> LevelSurveys { get; set; } = new List<LevelSurveyDefinition>();
         public List<LevelSurveyDefinition> AllLevelSurveys => AllDefinitions(LevelSurvey, LevelSurveys);
 
+        public bool IsDisabled => Priority <= 0;
+
         public bool IsPrefaceExpected => PrefaceRowCount > 0
                                                || !string.IsNullOrEmpty(PrefaceEndsWith)
                                                || !string.IsNullOrEmpty(PrefaceEndsBefore)
@@ -80,7 +83,7 @@ namespace TabularCsv
 
     public class TimestampDefinition : ColumnDefinition
     {
-        public string Format { get; set; }
+        public string[] Formats { get; set; }
         public TimestampType? Type { get; set; }
         public PropertyDefinition UtcOffset { get; set; }
     }

--- a/src/TabularCsv/Parser.cs
+++ b/src/TabularCsv/Parser.cs
@@ -158,6 +158,12 @@ namespace TabularCsv
                     ++dataRowCount;
                 }
 
+                if (dataRowCount == 0 && configuration.NoDataRowsExpected)
+                {
+                    // When all the data comes from the preface, then this will parse the preface context
+                    rowParser.Parse(new string[0]);
+                }
+
                 return ParseFileResult.SuccessfullyParsedAndDataValid();
             }
         }
@@ -251,10 +257,13 @@ namespace TabularCsv
                 Log = Log
             };
 
-            var configurations = configurationDirectory
+            var allConfigurations = configurationDirectory
                 .GetFiles("*.toml")
                 .Select(fileInfo => configurationLoader.Load(fileInfo.FullName))
-                .Where(configuration => configuration?.Priority > 0)
+                .ToList();
+
+            var configurations = allConfigurations
+                .Where(configuration => !configuration?.IsDisabled ?? false)
                 .OrderBy(configuration => configuration.Priority)
                 .ToList();
 

--- a/src/TabularCsv/RowParser.cs
+++ b/src/TabularCsv/RowParser.cs
@@ -404,9 +404,22 @@ namespace TabularCsv
             {
                 var timeText = GetString(timestampColumn);
 
-                if (!DateTimeOffset.TryParseExact(timeText, timestampColumn.Format, CultureInfo.InvariantCulture,
-                    DateTimeStyles.None, out var value))
-                    throw new Exception($"Line {LineNumber}: '{timeText}' can't be parsed as a timestamp using the '{timestampColumn.Format}' format.");
+                const IFormatProvider currentThreadCulture = null;
+                const DateTimeStyles styles = DateTimeStyles.AllowWhiteSpaces;
+
+                var formats = timestampColumn.Formats;
+                DateTimeOffset value;
+
+                if (formats == null || !formats.Any())
+                {
+                    if (!DateTimeOffset.TryParse(timeText, currentThreadCulture, styles, out value))
+                        throw new Exception($"Line {LineNumber}: '{timeText}' can't be parsed as a timestamp using the default format.");
+                }
+                else
+                {
+                    if (!DateTimeOffset.TryParseExact(timeText, timestampColumn.Formats, currentThreadCulture, styles, out value))
+                        throw new Exception($"Line {LineNumber}: '{timeText}' can't be parsed as a timestamp using the '{string.Join(", ", formats)}' {"format".ToQuantity(formats.Length, ShowQuantityAs.None)}.");
+                }
 
                 if (!timestampColumn.Type.HasValue)
                     throw new Exception($"{timestampColumn.Name()} has no configured {nameof(timestampColumn.Type)}: You must specify one of {string.Join(", ", Enum.GetNames(typeof(TimestampType)))}");


### PR DESCRIPTION
1) Configurations with Priority <= 0 are considered disabled and are not validated or processed

2) Added Configuration.NoDataRowsExpected property

Set this to true when all the field visit data comes from the Preface (say, if the text file is generated from a form)

3) The default TimestampDefinition.TimestampType is DateTimeOnly

The default timestamp now assumes times are local to the location, which seems to be most common.

4) Support multiple timestamp Formats

The TimestampDefinition.Formats property is now an array, and supports multiple format specifications if needed.

5) The default timestamp format is the .NET "try all the culture specific formats"

The TimestampDefinition.Formats property is empty by default.

When empty, use the .NET DateTimeOffset.TryParse() method which attempts all the culture-specific date time formats.

This is often good enough for most parsing scenarios.