### PR TITLE
PF-705 - Added Reading.AllowEmptyValues property

### DIFF
--- a/src/TabularCsv/Configuration.cs
+++ b/src/TabularCsv/Configuration.cs
@@ -143,6 +143,7 @@ namespace TabularCsv
 
     public class ReadingDefinition : ActivityDefinition
     {
+        public PropertyDefinition AllowEmptyValues { get; set; }
         public PropertyDefinition Value { get; set; }
         public PropertyDefinition ParameterId { get; set; }
         public PropertyDefinition UnitId { get; set; }

--- a/src/TabularCsv/RowParser.cs
+++ b/src/TabularCsv/RowParser.cs
@@ -528,20 +528,23 @@ namespace TabularCsv
 
         private Reading ParseReading(FieldVisitInfo visitInfo, ReadingDefinition definition)
         {
+            var allowEmptyValues = GetNullableBoolean(definition.AllowEmptyValues) ?? false;
+            var readingValue = GetNullableDouble(definition.Value);
             var parameterId = GetString(definition.ParameterId);
+            var readingUnitId = GetString(definition.UnitId);
 
-            if (string.IsNullOrEmpty(parameterId))
+            if (!allowEmptyValues && !readingValue.HasValue)
                 return null;
 
-            var readingValue = GetNullableDouble(definition.Value);
-            var readingUnitId = GetString(definition.UnitId);
+            if (allowEmptyValues && string.IsNullOrEmpty(parameterId))
+                return null;
 
             var reading = readingValue.HasValue
                 ? new Reading(
-                    GetString(definition.ParameterId),
+                    parameterId,
                     new Measurement(readingValue.Value, readingUnitId))
                 : new Reading(
-                    GetString(definition.ParameterId),
+                    parameterId,
                     readingUnitId,
                     null);
 


### PR DESCRIPTION
When 'true', allow the creation of readings with no values.