### PR TITLE
PF-1438 - Don't create a control condition activity if no properties …

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Choose the appropriate version of the plugin for your AQTS app server.
 
 | AQTS Version | Latest compatible plugin Version |
 | --- | --- |
-| AQTS 2021.4 Update 1 | [v21.4.6](https://github.com/AquaticInformatics/tabular-field-data-plugin/releases/download/v21.4.6/TabularCsv.plugin) |
+| AQTS 2021.4 Update 1 | [v21.4.7](https://github.com/AquaticInformatics/tabular-field-data-plugin/releases/download/v21.4.7/TabularCsv.plugin) |
 | AQTS 2021.4 | [v21.4.0](https://github.com/AquaticInformatics/tabular-field-data-plugin/releases/download/v21.4.0/TabularCsv.plugin) |
 | AQTS 2021.3 Update 1 | [v21.3.0](https://github.com/AquaticInformatics/tabular-field-data-plugin/releases/download/v21.3.0/TabularCsv.plugin) |
 | AQTS 2021.3<br/>AQTS 2021.2<br/>AQTS 2021.1<br/>AQTS 2020.4<br/>AQTS 2020.3 | [v20.3.16](https://github.com/AquaticInformatics/tabular-field-data-plugin/releases/download/v20.3.16/TabularCsv.plugin) |

--- a/src/TabularCsv/RowParser.cs
+++ b/src/TabularCsv/RowParser.cs
@@ -923,7 +923,21 @@ namespace TabularCsv
                 controlCondition.DistanceToGage = new Measurement(distanceToGage.Value, unitId);
             }
 
+            if (IsControlConditionEmpty(controlCondition))
+                return null;
+
             return controlCondition;
+        }
+
+        private bool IsControlConditionEmpty(ControlCondition controlCondition)
+        {
+            // We don't include "empty" tests for DateCleaned, since that is often inherited from the visit
+            return string.IsNullOrWhiteSpace(controlCondition.Party)
+                   && string.IsNullOrWhiteSpace(controlCondition.Comments)
+                   && controlCondition.ControlCode == null
+                   && controlCondition.ConditionType == null
+                   && controlCondition.ControlCleaned == ControlCleanedType.Unknown
+                   && controlCondition.DistanceToGage == null;
         }
 
         private GageZeroFlowActivity ParseGageAtZeroFlow(FieldVisitInfo visitInfo, GageAtZeroFlowDefinition definition)


### PR DESCRIPTION
…were set.

A ControlCondition doesn't have any required properties.

So skip its creation if it is empty (ie. when nothing from the CSV populated it)