### PR TITLE
Fix well integrity parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Choose the appropriate version of the plugin for your AQTS app server.
 
 | AQTS Version | Latest compatible plugin Version |
 | --- | --- |
+| AQTS 2025.4 | [v25.4.0](https://github.com/AquaticInformatics/tabular-field-data-plugin/releases/download/v25.4.0/TabularCsv.plugin) |
 | AQTS 2021.4 Update 1 | [v21.4.12](https://github.com/AquaticInformatics/tabular-field-data-plugin/releases/download/v21.4.12/TabularCsv.plugin) |
 | AQTS 2021.4 | [v21.4.0](https://github.com/AquaticInformatics/tabular-field-data-plugin/releases/download/v21.4.0/TabularCsv.plugin) |
 | AQTS 2021.3 Update 1 | [v21.3.0](https://github.com/AquaticInformatics/tabular-field-data-plugin/releases/download/v21.3.0/TabularCsv.plugin) |

--- a/src/BlazorTestDrive/BlazorTestDrive.csproj
+++ b/src/BlazorTestDrive/BlazorTestDrive.csproj
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
 	<TargetFramework>net10.0</TargetFramework>
-	  <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-
-	         <Nullable>enable</Nullable>
+    <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
+    <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
@@ -32,6 +31,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Examples\WellIntegrity.csv" />
+    <EmbeddedResource Include="Examples\WellIntegrity.toml" />
     <EmbeddedResource Include="Examples\HydraulicTests.csv" />
     <EmbeddedResource Include="Examples\HydraulicTests.toml" />
     <EmbeddedResource Include="Examples\AirTemperatureWithExtendedAttributes.csv" />

--- a/src/BlazorTestDrive/Components/VisitPanel.razor
+++ b/src/BlazorTestDrive/Components/VisitPanel.razor
@@ -529,33 +529,7 @@
                         {
                             @foreach (var item in Visit.WellIntegrity)
                             {
-                                <div style="margin-bottom:8px;">
-                                    @if (item.WellAquiferConnections.Any())
-                                    {
-                                        <h5>@($"WellAquiferConnections {item.WellAquiferConnections.Count}")</h5>
-                                        <table class="RTable">
-                                            <thead>
-                                                <tr>
-                                                    <th>Start Date</th>
-                                                    <th>Aquifer Connectivity Type</th>
-                                                    <th>Inspection Method</th>
-                                                    <th>Comments</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                @foreach (var ac in item.WellAquiferConnections)
-                                                {
-                                                    <tr>
-                                                        <td>@ac.StartDate</td>
-                                                        <td>@ac.WellAquiferConnectivityType.IdOrDisplayName</td>
-                                                        <td>@ac.WellInspectionMethodType.IdOrDisplayName</td>
-                                                        <td>@ac.Comments</td>
-                                                    </tr>
-                                                }
-                                            </tbody>
-                                        </table>
-                                    }
-                                </div>
+                                <WellIntegrityPanel Activity="item" />
                             }
                         }
                         else

--- a/src/BlazorTestDrive/Components/WellIntegrityPanel.razor
+++ b/src/BlazorTestDrive/Components/WellIntegrityPanel.razor
@@ -1,0 +1,204 @@
+@using System.Text
+@using FieldDataPluginFramework.DataModel
+@using FieldDataPluginFramework.DataModel.WellIntegrity
+
+@inherits Microsoft.AspNetCore.Components.ComponentBase
+
+@code {
+    private WellIntegrity _wellIntegrity;
+    [Parameter] public WellIntegrity Activity
+    {
+        get => _wellIntegrity;
+        set
+        {
+            _wellIntegrity = value;
+            SetupTabDisplayNames();
+        }
+    }
+
+    private int SelectedTab { get; set; }
+    private void Select(int index) => SelectedTab = index;
+
+    private enum Tab
+    {
+        AquiferConnections = 0,
+        Inspections = 1,
+        Redevelopments = 2,
+        Repairs = 3,
+    }
+
+    private Dictionary<Tab, string> TabDisplayNames = new Dictionary<Tab, string>();
+
+    private void SetupTabDisplayNames()
+    {
+        TabDisplayNames.Clear();
+        if (Activity == null) return;
+
+        var aquiferConnectionCount = Activity.WellAquiferConnections.Count();
+        var inspectionCount = Activity.WellInspections.Count();
+        var redevelopmentCount = Activity.WellRedevelopments.Count();
+        var repairCount = Activity.WellRepairs.Count();
+
+        TabDisplayNames[Tab.AquiferConnections] = "Aquifer Connections" + (aquiferConnectionCount > 0 ? $" ({aquiferConnectionCount})" : "");
+        TabDisplayNames[Tab.Inspections] = "Inspections" + (inspectionCount > 0 ? $" ({inspectionCount})" : "");
+        TabDisplayNames[Tab.Redevelopments] = "Redevelopments" + (redevelopmentCount > 0 ? $" ({redevelopmentCount})" : "");
+        TabDisplayNames[Tab.Repairs] = "Repairs" + (repairCount > 0 ? $" ({repairCount})" : "");
+    }
+}
+
+<details class="well-integrity-panel" style="margin-bottom:12px;">
+
+    <div class="tab-row">
+        @foreach (var kvp in TabDisplayNames)
+        {
+            <button class="tab-button" style="margin-right:6px; padding:4px 8px;" @onclick="() => Select((int)kvp.Key)">
+                @kvp.Value
+            </button>
+        }
+    </div>
+
+    <div class="tab-content">
+        @switch ((Tab)SelectedTab)
+        {
+            case Tab.AquiferConnections:
+                <div>
+                    @if (Activity.WellAquiferConnections.Any())
+                    {
+                        <table class="RTable">
+                            <thead>
+                                <tr>
+                                    <th>Start Date</th>
+                                    <th>Aquifer Connectivity Type</th>
+                                    <th>Inspection Method</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var ac in Activity.WellAquiferConnections)
+                                {
+                                    <tr>
+                                        <td>@ac.StartDate</td>
+                                        <td>@ac.WellAquiferConnectivityType.IdOrDisplayName</td>
+                                        <td>@ac.WellInspectionMethodType.IdOrDisplayName</td>
+                                        <td>@ac.Comments</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    }
+                    else
+                    {
+                        <div>No well aquifer connections.</div>
+                    }
+                </div>
+                break;
+
+            case Tab.Inspections:
+                <div>
+                @if (Activity.WellInspections.Any())
+                    {
+                        <table class="RTable">
+                            <thead>
+                                <tr>
+                                    <th>Start Date</th>
+                                    <th>Well Component Type</th>
+                                    <th>Well Condition Type</th>
+                                    <th>Well Inspection Method</th>
+                                    <th>Distance From</th>
+                                    <th>Distance To</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var i in Activity.WellInspections)
+                                {
+                                    <tr>
+                                        <td>@i.StartDate</td>
+                                        <td>@i.WellComponentType.IdOrDisplayName</td>
+                                        <td>@i.WellConditionType.IdOrDisplayName</td>
+                                        <td>@i.WellInspectionMethod.IdOrDisplayName</td>
+                                        <td>@VisitHelpers.Measurement(new Measurement(i.DistanceFrom, i.DistanceUnitId))</td>
+                                        <td>@VisitHelpers.Measurement(new Measurement(i.DistanceTo, i.DistanceUnitId))</td>
+                                        <td>@i.Comments</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    }
+                    else
+                    {
+                        <div>No well inspections.</div>
+                    }
+                </div>
+                break;
+
+            case Tab.Redevelopments:
+                <div>
+                    @if (Activity.WellRedevelopments.Any())
+                    {
+                        <table class="RTable">
+                            <thead>
+                                <tr>
+                                    <th>Start Date</th>
+                                    <th>End Date</th>
+                                    <th>Attempt</th>
+                                    <th>Redevelopment Method Type</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var r in Activity.WellRedevelopments)
+                                {
+                                    <tr>
+                                        <td>@r.StartDate</td>
+                                        <td>@r.EndDate</td>
+                                        <td>@r.Attempt</td>
+                                        <td>@r.WellRedevelopmentMethodType.IdOrDisplayName</td>
+                                        <td>@r.Comments</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    }
+                    else
+                    {
+                        <div>No well redevelopments.</div>
+                    }
+                </div>
+                break;
+
+            case Tab.Repairs:
+                <div>
+                    @if (Activity.WellRepairs.Any())
+                    {
+                        <table class="RTable">
+                            <thead>
+                                <tr>
+                                    <th>Start Date</th>
+                                    <th>End Date</th>
+                                    <th>Repair Type</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var r in Activity.WellRepairs)
+                                {
+                                    <tr>
+                                        <td>@r.StartDate</td>
+                                        <td>@r.EndDate</td>
+                                        <td>@r.WellRepairType.IdOrDisplayName</td>
+                                        <td>@r.Comments</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    }
+                    else
+                    {
+                        <div>No well repairs.</div>
+                    }
+                </div>
+                break;
+        }
+    </div>
+</details>

--- a/src/BlazorTestDrive/Examples.cs
+++ b/src/BlazorTestDrive/Examples.cs
@@ -82,7 +82,12 @@ Uses aliases to work around old stations that have been renamed in AQUARIUS.",
                 Name = "Hydraulic test data",
                 Description = "This example demonstrates how to parse hydraulic test data.",
             },
-
+            new Example
+            {
+                Id = "WellIntegrity",
+                Name = "Well integrity records",
+                Description = "This example demonstrates how to parse well integrity records.",
+            },
         }
             .Select(LoadEmbeddedResources)
             .ToList();

--- a/src/BlazorTestDrive/Examples/TesterOptions.txt
+++ b/src/BlazorTestDrive/Examples/TesterOptions.txt
@@ -11,3 +11,4 @@
 /Setting=Spanish=@..\..\..\BlazorTestDrive\Examples\Spanish.toml
 /Setting=StageDischargeReadingsFormat=@..\..\..\BlazorTestDrive\Examples\StageDischargeReadingsFormat.toml
 /Setting=Survey123Example=@..\..\..\BlazorTestDrive\Examples\Survey123Example.toml
+/Setting=WellIntegrity=@..\..\..\BlazorTestDrive\Examples\WellIntegrity.toml

--- a/src/BlazorTestDrive/Examples/WellIntegrity.csv
+++ b/src/BlazorTestDrive/Examples/WellIntegrity.csv
@@ -1,0 +1,9 @@
+The Location, The Time, AquiferConnectivity, InspectionMethodType, WellComponent, WellCondition, InspectionMethod, DistanceFrom, DistanceTo, RedevelopmentMethod, RepairType, Comments
+LOC1, 2020-Jan-12 12:35,              con 1,               insp 1
+LOC1, 2020-Jan-12 12:35,              con 2,               insp 2
+LOC1, 2020-Jan-12 12:35,              con 1,               insp 1,        comp 1,         cond 1,          insp 1,           12,         20,
+LOC1, 2020-Jan-12 12:35,              con 1,               insp 1,        comp 1,         cond 1,          insp 1,           12,         20,          redevmeth1, repairtyp1, my comment
+
+
+LOC2, 1988-Aug-8 15:10,                    ,                    ,              ,                ,               ,             ,            ,          redevMeth1, repair type 1
+LOC2, 1988-Aug-8 15:10,                    ,                    ,              ,                ,               ,             ,            ,          redevMeth2, repair type 2

--- a/src/BlazorTestDrive/Examples/WellIntegrity.toml
+++ b/src/BlazorTestDrive/Examples/WellIntegrity.toml
@@ -1,0 +1,26 @@
+Location = '@The Location'
+Time = '@The Time'
+
+[WellIntegrity]
+
+[[WellIntegrity.WellAquiferConnections]]
+WellAquiferConnectivityType = '@AquiferConnectivity'
+WellInspectionMethodType = '@InspectionMethodType'
+Comment = '@Comments'
+
+[[WellIntegrity.WellInspections]]
+WellComponentType = '@WellComponent'
+WellConditionType = '@WellCondition'
+WellInspectionMethod = '@InspectionMethod'
+DistanceFrom = '@DistanceFrom'
+DistanceTo = '@DistanceTo'
+DistanceUnitId = 'ft'
+Comment = '@Comments'
+
+[[WellIntegrity.WellRedevelopments]]
+WellRedevelopmentMethodType = '@RedevelopmentMethod'
+Comment = '@Comments'
+
+[[WellIntegrity.WellRepairs]]
+WellRepairType = '@RepairType'
+Comment = '@Comments'

--- a/src/TabularCsv/DelayedAppender.cs
+++ b/src/TabularCsv/DelayedAppender.cs
@@ -417,7 +417,38 @@ namespace TabularCsv
 
         public void AddWellIntegrity(FieldVisitInfo fieldVisit, WellIntegrity wellIntegrity)
         {
-            fieldVisit.WellIntegrity.Add(wellIntegrity);
+            var existingWellIntegrity = fieldVisit.WellIntegrity.FirstOrDefault();
+            if (existingWellIntegrity != null)
+            {
+                MergeWellIntegrity(existingWellIntegrity, wellIntegrity);
+            }
+            else
+            {
+                fieldVisit.WellIntegrity.Add(wellIntegrity);
+            }
+        }
+
+        private void MergeWellIntegrity(WellIntegrity existing, WellIntegrity incoming)
+        {
+            foreach (var connection in incoming.WellAquiferConnections)
+            {
+                existing.WellAquiferConnections.Add(connection);
+            }
+
+            foreach (var inspection in incoming.WellInspections)
+            {
+                existing.WellInspections.Add(inspection);
+            }
+
+            foreach (var redevelopment in incoming.WellRedevelopments)
+            {
+                existing.WellRedevelopments.Add(redevelopment);
+            }
+
+            foreach (var repair in incoming.WellRepairs)
+            {
+                existing.WellRepairs.Add(repair);
+            }
         }
 
         public void AddHydraulicTest(FieldVisitInfo fieldVisit, HydraulicTest hydraulicTest)


### PR DESCRIPTION
@ChrisKanaganayagam-AI @AlvinLee-AI I'm back from vacation, quickly cobbled up the remaining the `WellIntegrity` CSV and TOML example, and promptly found a bug!

This PR adds the example files and fixes the discovered bug.

I also noticed a couple of deployment quirks that someone at AquaticInformatics will need to fix, since I don't have project rights anymore.

## Fix the published release version in the AppVeyor project
- Change the AppVeyor project version to `25.4` and reset the next counter to `0`

That should publish the next build of the plugin as `v25.4.0` instead of `v21.4.14`, which aligns better with the expected plugin version naming patter. A plugin version of `25.4.x` implies that the plugin will be compatible with AQTS 2025.4-or-higher.

## Manually deploy the updated Blazor TestDrive project to GitHub pages

The previous version of the plugin from 4 years ago is still deployed at https://aquaticinformatics.github.io/tabular-field-data-plugin/test-drive/ so nobody can test the new functionality.

Someone with project admin rights will need to do this after the PR is merged:
- Pull the latest `master` branch locally
- Build the Solution in Release mode
- Run `docs/publish-test-drive.sh` to publish the updated test drive project to GitHub Pages

Cheers!